### PR TITLE
feat: 添加数据库存储支持，优化性能与内存管理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,13 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.nukkitx</groupId>
+            <artifactId>fakeinventories</artifactId>
+            <version>1.0.3-MOT-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 
@@ -52,6 +59,35 @@
                     <target>${maven.compiler.target}</target>
                     <encoding>${maven.compiler.encoding}</encoding>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.nukkitx.fakeinventories</pattern>
+                                    <shadedPattern>org.badfish.signin.shaded.fakeinventories</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>com.nukkitx:fakeinventories</artifact>
+                                    <includes>
+                                        <include>com/nukkitx/fakeinventories/inventory/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>cn.nukkit</groupId>
             <artifactId>Nukkit</artifactId>
             <version>MOT-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.badfish.signin</groupId>
     <artifactId>SignIn</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
             <id>repo-lanink-cn</id>
             <url>https://repo.lanink.cn/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -43,6 +47,20 @@
             <artifactId>fakeinventories</artifactId>
             <version>1.0.3-MOT-SNAPSHOT</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.MufHead.YRDatabase</groupId>
+            <artifactId>yrdatabase-api</artifactId>
+            <version>v2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.MufHead.YRDatabase</groupId>
+            <artifactId>yrdatabase-nukkit</artifactId>
+            <version>v2.0.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/badfish/signin/SignInListener.java
+++ b/src/main/java/org/badfish/signin/SignInListener.java
@@ -25,6 +25,7 @@ import org.badfish.signin.items.RoundItem;
 import org.badfish.signin.manager.PlayerSignManager;
 import org.badfish.signin.panel.ChestInventoryPanel;
 import org.badfish.signin.panel.DisplayPanel;
+import com.nukkitx.fakeinventories.inventory.FakeInventory;
 import org.badfish.signin.items.DateItem;
 import org.badfish.signin.utils.ItemType;
 import org.badfish.signin.utils.Tool;
@@ -70,7 +71,7 @@ public class SignInListener implements Listener {
         InventoryTransaction transaction = event.getTransaction();
         for (InventoryAction action : transaction.getActions()) {
             for (Inventory inventory : transaction.getInventories()) {
-                if (inventory instanceof ChestInventoryPanel) {
+                if (inventory instanceof ChestInventoryPanel || inventory instanceof FakeInventory) {
                     event.setCancelled();
                     for (Player player : inventory.getViewers()) {
                         Item item = action.getSourceItem();
@@ -175,6 +176,7 @@ public class SignInListener implements Listener {
 
     @EventHandler
     public void onQuit(PlayerQuitEvent e){
+        isLogin.remove(e.getPlayer());
         PlayerSignInData signInData = SignInMainClass.PLAYER_SIGN_IN_MANAGER.getPlayerData(e.getPlayer().getName());
         signInData.save();
     }

--- a/src/main/java/org/badfish/signin/SignInListener.java
+++ b/src/main/java/org/badfish/signin/SignInListener.java
@@ -27,6 +27,7 @@ import com.nukkitx.fakeinventories.inventory.FakeInventory;
 import org.badfish.signin.items.DateItem;
 import org.badfish.signin.utils.ItemType;
 import org.badfish.signin.utils.Tool;
+import cn.nukkit.scheduler.AsyncTask;
 import java.util.ArrayList;
 import java.util.Date;
 
@@ -41,20 +42,27 @@ public class SignInListener implements Listener {
     public void onJoinCheck(PlayerLocallyInitializedEvent event){
         //玩家真正的进服
         if(isLogin.contains(event.getPlayer())){
-            PlayerSignInData signManager = SignInMainClass.PLAYER_SIGN_IN_MANAGER.getPlayerData(event.getPlayer().getName());
-            if(!signManager.isSignIn(new Date())){
-                DisplayPanel p = new DisplayPanel();
-                Server.getInstance().getScheduler().scheduleDelayedTask(
-                        SignInMainClass.MAIN_INSTANCE,
-                        () -> {
-                            if (event.getPlayer().isOnline()) {
-                                p.sendMothPanel(event.getPlayer());
-                            }
-                        },
-                        10
-                );
-            }
             isLogin.remove(event.getPlayer());
+            Player player = event.getPlayer();
+            // 异步加载数据，避免阻塞主线程；加载完成后通过 putPlayerData 标记待验证，首次签到前会重新从 DB 拉取最新数据
+            Server.getInstance().getScheduler().scheduleAsyncTask(SignInMainClass.MAIN_INSTANCE, new AsyncTask() {
+                PlayerSignInData data;
+                @Override
+                public void onRun() {
+                    data = SignInMainClass.DATA_STORAGE.load(player.getName());
+                    if (data == null) data = new PlayerSignInData(player.getName());
+                    if (data.getSignMonth() == -1) data.setSignMonth(Tool.geMonth());
+                    if (data.getSignMonth() != Tool.geMonth()) data.reset();
+                }
+                @Override
+                public void onCompletion(Server server) {
+                    if (!player.isOnline()) return;
+                    SignInMainClass.PLAYER_SIGN_IN_MANAGER.putPlayerData(player.getName(), data);
+                    if (!data.isSignIn(new Date())) {
+                        new DisplayPanel().sendMothPanel(player);
+                    }
+                }
+            });
         }
     }
 
@@ -85,7 +93,41 @@ public class SignInListener implements Listener {
                                             case THIS:
                                                 if(item.getNamedTag().getBoolean(DateItem.TAG+"sign")){
                                                     player.sendMessage(TextFormat.colorize('&',"&2您已经签到过了"));
-                                                }else{
+                                                } else if (SignInMainClass.PLAYER_SIGN_IN_MANAGER.needsVerification(player.getName())) {
+                                                    // 从其他子服切换过来的首次签到，异步从 DB 拉取最新数据验证，防止重复签到
+                                                    SignInMainClass.PLAYER_SIGN_IN_MANAGER.markVerified(player.getName());
+                                                    final int verifyDay = day;
+                                                    final Inventory verifyInventory = inventory;
+                                                    Server.getInstance().getScheduler().scheduleAsyncTask(SignInMainClass.MAIN_INSTANCE, new AsyncTask() {
+                                                        PlayerSignInData fresh;
+                                                        @Override
+                                                        public void onRun() {
+                                                            fresh = SignInMainClass.DATA_STORAGE.load(player.getName());
+                                                        }
+                                                        @Override
+                                                        public void onCompletion(Server server) {
+                                                            if (!player.isOnline()) return;
+                                                            PlayerSignInData current = SignInMainClass.PLAYER_SIGN_IN_MANAGER.getPlayerData(player.getName());
+                                                            // 若本地缓存已签到（如快速重复点击），只刷新面板
+                                                            if (current.isSignIn(Tool.getDateByDay(verifyDay))) {
+                                                                verifyInventory.setContents(DisplayPanel.getDatePanel(player));
+                                                                return;
+                                                            }
+                                                            // 用 DB 最新数据覆盖缓存
+                                                            if (fresh != null) {
+                                                                SignInMainClass.PLAYER_SIGN_IN_MANAGER.refreshCache(player.getName(), fresh);
+                                                                current = fresh;
+                                                            }
+                                                            if (current.isSignIn(Tool.getDateByDay(verifyDay))) {
+                                                                // 其他子服已签到
+                                                                player.sendMessage(TextFormat.colorize('&', "&2您已经签到过了"));
+                                                                verifyInventory.setContents(DisplayPanel.getDatePanel(player));
+                                                            } else {
+                                                                signIn(player, current, verifyInventory, verifyDay);
+                                                            }
+                                                        }
+                                                    });
+                                                } else {
                                                     signIn(player,signInData,inventory,day);
                                                 }
                                                 break;

--- a/src/main/java/org/badfish/signin/SignInListener.java
+++ b/src/main/java/org/badfish/signin/SignInListener.java
@@ -14,7 +14,6 @@ import cn.nukkit.inventory.transaction.InventoryTransaction;
 import cn.nukkit.inventory.transaction.action.InventoryAction;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Sound;
-import cn.nukkit.network.protocol.SetLocalPlayerAsInitializedPacket;
 import cn.nukkit.utils.TextFormat;
 import org.badfish.signin.data.BaseRewardData;
 import org.badfish.signin.data.DateRewardData;
@@ -22,7 +21,6 @@ import org.badfish.signin.data.PlayerSignInData;
 import org.badfish.signin.data.SignInRewardData;
 import org.badfish.signin.items.CmdItem;
 import org.badfish.signin.items.RoundItem;
-import org.badfish.signin.manager.PlayerSignManager;
 import org.badfish.signin.panel.ChestInventoryPanel;
 import org.badfish.signin.panel.DisplayPanel;
 import com.nukkitx.fakeinventories.inventory.FakeInventory;
@@ -37,7 +35,8 @@ import java.util.Date;
  */
 public class SignInListener implements Listener {
 
-    private ArrayList<Player> isLogin = new ArrayList<>();
+    private final ArrayList<Player> isLogin = new ArrayList<>();
+
     @EventHandler
     public void onJoinCheck(PlayerLocallyInitializedEvent event){
         //玩家真正的进服
@@ -113,7 +112,7 @@ public class SignInListener implements Listener {
                                     case REWARD:
                                         ArrayList<BaseRewardData> arrayList = SignInMainClass.ITEM_REWARD_MANAGER.getPlayerAllCumulativeData(signInData);
                                         int maxCount = 0;
-                                        if(arrayList.size() > 0){
+                                        if(!arrayList.isEmpty()){
                                             for(BaseRewardData data: arrayList){
                                                 if(data.getDay() > maxCount){
                                                     maxCount = data.getDay();
@@ -123,6 +122,7 @@ public class SignInListener implements Listener {
                                         }
                                         if(maxCount > 0 && maxCount > signInData.getCumulativeCount()){
                                             signInData.setCumulativeCount(maxCount);
+                                            signInData.saveAsync();
                                         }
                                         //刷新布局
                                         inventory.setContents(DisplayPanel.getDatePanel(player));
@@ -152,6 +152,7 @@ public class SignInListener implements Listener {
             player.sendMessage(TextFormat.colorize('&',"&r"+dateRewardData.getDisplayName()+" &r&e奖励"));
             putPlayer(dateRewardData,player);
         }
+        signInData.saveAsync();
     }
 
     /**
@@ -169,7 +170,6 @@ public class SignInListener implements Listener {
                     player.sendMessage(TextFormat.colorize('&',"&d额外获得: &r"+cmdItem.getName()));
                     Server.getInstance().getCommandMap().dispatch(new ConsoleCommandSender(),cmdItem.getCmd().replace("@p",player.getName()));
                 }
-//
             }
         }
     }
@@ -177,7 +177,9 @@ public class SignInListener implements Listener {
     @EventHandler
     public void onQuit(PlayerQuitEvent e){
         isLogin.remove(e.getPlayer());
-        PlayerSignInData signInData = SignInMainClass.PLAYER_SIGN_IN_MANAGER.getPlayerData(e.getPlayer().getName());
-        signInData.save();
+        String playerName = e.getPlayer().getName();
+        PlayerSignInData signInData = SignInMainClass.PLAYER_SIGN_IN_MANAGER.getPlayerData(playerName);
+        signInData.saveAsync();
+        SignInMainClass.PLAYER_SIGN_IN_MANAGER.removePlayerData(playerName);
     }
 }

--- a/src/main/java/org/badfish/signin/SignInMainClass.java
+++ b/src/main/java/org/badfish/signin/SignInMainClass.java
@@ -6,6 +6,7 @@ import cn.nukkit.Server;
 import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.plugin.PluginBase;
+import cn.nukkit.scheduler.AsyncTask;
 import cn.nukkit.utils.TextFormat;
 import org.badfish.signin.data.PlayerSignInData;
 import org.badfish.signin.manager.ItemRewardManager;
@@ -57,7 +58,7 @@ public class SignInMainClass extends PluginBase {
     @Override
     public void onDisable() {
         if (PLAYER_SIGN_IN_MANAGER != null && DATA_STORAGE != null) {
-            DATA_STORAGE.saveAll(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData());
+            DATA_STORAGE.saveAll(new ArrayList<>(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()));
         }
         if (DATA_STORAGE != null) {
             DATA_STORAGE.close();
@@ -94,7 +95,7 @@ public class SignInMainClass extends PluginBase {
         return (ArrayList<String>) getConfig().getStringList("border-lore");
     }
 
-    private void loadConfig(){
+    private void loadConfig() {
         this.saveDefaultConfig();
         this.reloadConfig();
         ITEM_REWARD_MANAGER = ItemRewardManager.managerCreate(getConfig());
@@ -113,7 +114,7 @@ public class SignInMainClass extends PluginBase {
                         switch (type) {
                             case RELOAD:
                                 if (PLAYER_SIGN_IN_MANAGER != null && DATA_STORAGE != null) {
-                                    DATA_STORAGE.saveAll(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData());
+                                    DATA_STORAGE.saveAll(new ArrayList<>(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()));
                                     DATA_STORAGE.close();
                                 }
                                 loadConfig();
@@ -149,8 +150,13 @@ public class SignInMainClass extends PluginBase {
                                         Player p = Server.getInstance().getPlayer(playerName);
                                         if(p != null){
                                             players.add(p);
+                                        } else {
+                                            // 离线玩家直接加载数据
+                                            signInData = PLAYER_SIGN_IN_MANAGER.getPlayerData(playerName);
+                                            signInData.addRetroactiveCount(count);
+                                            signInData.save();
+                                            PLAYER_SIGN_IN_MANAGER.removePlayerData(playerName);
                                         }
-
                                     }
                                     for(Player player: players){
                                         if(player != null){
@@ -159,7 +165,7 @@ public class SignInMainClass extends PluginBase {
                                         }
                                         signInData = PLAYER_SIGN_IN_MANAGER.getPlayerData(playerName);
                                         signInData.addRetroactiveCount(count);
-
+                                        signInData.saveAsync();
                                     }
                                     sender.sendMessage(TextFormat.colorize('&',"&7成功给予玩家 &e"+send+" &2"+count+" &7张补签卡"));
 
@@ -177,10 +183,27 @@ public class SignInMainClass extends PluginBase {
                                 sender.sendMessage("/qd reload 重载配置文件");
                                 break;
                             case RESET:
-                                for (PlayerSignInData signInData : PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()) {
+                                sender.sendMessage("正在重置玩家数据...");
+                                // 重置缓存中的在线玩家（主线程，缓存操作）
+                                for (PlayerSignInData signInData : new ArrayList<>(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData())) {
                                     signInData.reset();
                                 }
-                                sender.sendMessage("重置完成");
+                                // 离线玩家：异步加载并重置
+                                Server.getInstance().getScheduler().scheduleAsyncTask(MAIN_INSTANCE, new AsyncTask() {
+                                    @Override
+                                    public void onRun() {
+                                        for (PlayerSignInData signInData : DATA_STORAGE.loadAll()) {
+                                            if (!PLAYER_SIGN_IN_MANAGER.containsPlayer(signInData.getPlayerName())) {
+                                                signInData.reset();
+                                            }
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onCompletion(Server server) {
+                                        sender.sendMessage("重置完成");
+                                    }
+                                });
                                 break;
                             default:
                                 break;

--- a/src/main/java/org/badfish/signin/SignInMainClass.java
+++ b/src/main/java/org/badfish/signin/SignInMainClass.java
@@ -12,6 +12,8 @@ import org.badfish.signin.manager.ItemRewardManager;
 import org.badfish.signin.manager.PlayerSignManager;
 import org.badfish.signin.panel.DisplayPanel;
 import org.badfish.signin.panel.lib.AbstractFakeInventory;
+import org.badfish.signin.storage.provider.DataStorageProvider;
+import org.badfish.signin.storage.DataStorageFactory;
 
 import org.badfish.signin.utils.CommandType;
 
@@ -30,6 +32,8 @@ public class SignInMainClass extends PluginBase {
     public static ItemRewardManager ITEM_REWARD_MANAGER;
 
     public static PlayerSignManager PLAYER_SIGN_IN_MANAGER;
+
+    public static DataStorageProvider DATA_STORAGE;
 
 
     @Override
@@ -52,10 +56,11 @@ public class SignInMainClass extends PluginBase {
 
     @Override
     public void onDisable() {
-        if (PLAYER_SIGN_IN_MANAGER != null) {
-            for (PlayerSignInData signInData : PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()) {
-                signInData.save();
-            }
+        if (PLAYER_SIGN_IN_MANAGER != null && DATA_STORAGE != null) {
+            DATA_STORAGE.saveAll(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData());
+        }
+        if (DATA_STORAGE != null) {
+            DATA_STORAGE.close();
         }
         AbstractFakeInventory.shutdown();
     }
@@ -93,8 +98,9 @@ public class SignInMainClass extends PluginBase {
         this.saveDefaultConfig();
         this.reloadConfig();
         ITEM_REWARD_MANAGER = ItemRewardManager.managerCreate(getConfig());
+        String storageType = getConfig().getString("storage-type", "yaml");
+        DATA_STORAGE = DataStorageFactory.create(storageType);
         PLAYER_SIGN_IN_MANAGER = PlayerSignManager.managerCreate();
-
     }
 
     @Override
@@ -106,8 +112,9 @@ public class SignInMainClass extends PluginBase {
                     if (type != null) {
                         switch (type) {
                             case RELOAD:
-                                for (PlayerSignInData signInData : PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()) {
-                                    signInData.save();
+                                if (PLAYER_SIGN_IN_MANAGER != null && DATA_STORAGE != null) {
+                                    DATA_STORAGE.saveAll(PLAYER_SIGN_IN_MANAGER.getPlayerSignInData());
+                                    DATA_STORAGE.close();
                                 }
                                 loadConfig();
                                 sender.sendMessage("配置重启完成");

--- a/src/main/java/org/badfish/signin/SignInMainClass.java
+++ b/src/main/java/org/badfish/signin/SignInMainClass.java
@@ -32,19 +32,32 @@ public class SignInMainClass extends PluginBase {
     public static PlayerSignManager PLAYER_SIGN_IN_MANAGER;
 
 
-
+    @Override
+    public void onLoad() {
+        MAIN_INSTANCE = this;
+    }
 
     @Override
     public void onEnable() {
-        MAIN_INSTANCE = this;
         this.getLogger().info("正在加载签到插件");
         //检查核心兼容
         checkServer();
         loadConfig();
 
+        this.getServer().getPluginManager().registerEvents(new SignInListener(),this);
+
         this.getLogger().info("签到插件加载完成 by 某吃瓜咸鱼");
         this.getLogger().info("本插件完全免费 如果你是购买的，那你就被坑了");
-        this.getServer().getPluginManager().registerEvents(new SignInListener(),this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (PLAYER_SIGN_IN_MANAGER != null) {
+            for (PlayerSignInData signInData : PLAYER_SIGN_IN_MANAGER.getPlayerSignInData()) {
+                signInData.save();
+            }
+        }
+        AbstractFakeInventory.shutdown();
     }
 
     private void checkServer(){
@@ -180,8 +193,5 @@ public class SignInMainClass extends PluginBase {
         }
         return true;
     }
-
-
-
 
 }

--- a/src/main/java/org/badfish/signin/data/PlayerSignInData.java
+++ b/src/main/java/org/badfish/signin/data/PlayerSignInData.java
@@ -4,6 +4,7 @@ package org.badfish.signin.data;
 import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.utils.Tool;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 
@@ -84,10 +85,19 @@ public class PlayerSignInData {
         return retroactiveCount;
     }
 
-    public void reset(){
+    public void reset() {
         setCumulativeCount(0);
         setSignMonth(Tool.geMonth());
-        save();
+        cleanOldSignInData();
+        saveAsync();
+    }
+
+    /**
+     * 清理非当月的签到日期数据
+     */
+    private void cleanOldSignInData() {
+        String currentPrefix = new SimpleDateFormat("yyyy-MM").format(new Date());
+        signIn.removeIf(date -> !date.startsWith(currentPrefix));
     }
 
     private ArrayList<String> getThisMonthSignInData(){
@@ -137,7 +147,22 @@ public class PlayerSignInData {
         return signIn;
     }
 
+    /**
+     * 创建当前数据的快照副本（用于异步保存）
+     */
+    public PlayerSignInData snapshot() {
+        PlayerSignInData copy = new PlayerSignInData(this.playerName, new ArrayList<>(this.signIn));
+        copy.setSignMonth(this.signMonth);
+        copy.setCumulativeCount(this.cumulativeCount);
+        copy.setRetroactiveCount(this.retroactiveCount);
+        return copy;
+    }
+
     public void save(){
         SignInMainClass.DATA_STORAGE.save(this);
+    }
+
+    public void saveAsync() {
+        SignInMainClass.DATA_STORAGE.saveAsync(this);
     }
 }

--- a/src/main/java/org/badfish/signin/data/PlayerSignInData.java
+++ b/src/main/java/org/badfish/signin/data/PlayerSignInData.java
@@ -1,7 +1,6 @@
 package org.badfish.signin.data;
 
 
-import cn.nukkit.utils.Config;
 import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.utils.Tool;
 
@@ -130,12 +129,15 @@ public class PlayerSignInData {
         this.cumulativeCount = cumulativeCount;
     }
 
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public ArrayList<String> getSignIn() {
+        return signIn;
+    }
+
     public void save(){
-        Config config = new Config(SignInMainClass.MAIN_INSTANCE.getDataFolder()+"/players/"+playerName+".yml",Config.YAML);
-        config.set("signInDate",signIn);
-        config.set("signMonth",signMonth);
-        config.set("cumulativeCount",cumulativeCount);
-        config.set("retroactiveCount",retroactiveCount);
-        config.save();
+        SignInMainClass.DATA_STORAGE.save(this);
     }
 }

--- a/src/main/java/org/badfish/signin/data/PlayerSignInData.java
+++ b/src/main/java/org/badfish/signin/data/PlayerSignInData.java
@@ -114,6 +114,11 @@ public class PlayerSignInData {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return playerName.hashCode();
+    }
+
     /**
      * 累计签到次数
      * */

--- a/src/main/java/org/badfish/signin/items/RoundItem.java
+++ b/src/main/java/org/badfish/signin/items/RoundItem.java
@@ -2,6 +2,7 @@ package org.badfish.signin.items;
 
 
 import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 
 
 /**
@@ -25,21 +26,8 @@ public class RoundItem {
         return cmdItems;
     }
 
-    /**计算小数位*/
-    private int mathRoundLine(double round){
-        int n = 0;
-        int i = (int)round;
-        while((round - i)>0) {
-            round = round*10;
-            i = (int)round;
-            n++;
-        }
-        return n;
-    }
     public boolean hasPull(){
-        int r = (int) (1 + Math.random() * Math.pow(10, mathRoundLine(round)));
-        int r2 = (int) (round * Math.pow(10, mathRoundLine(round)));
-        return r <= r2;
+        return ThreadLocalRandom.current().nextDouble() < round;
     }
 
 }

--- a/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
+++ b/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
@@ -6,21 +6,24 @@ import org.badfish.signin.data.PlayerSignInData;
 import org.badfish.signin.utils.Tool;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author BadFish
  */
 public class PlayerSignManager {
 
-    private ArrayList<PlayerSignInData> playerSignInData;
+    private Map<String, PlayerSignInData> playerSignInData;
 
-    private PlayerSignManager(ArrayList<PlayerSignInData> signInData){
+    private PlayerSignManager(Map<String, PlayerSignInData> signInData){
         this.playerSignInData = signInData;
     }
 
     public static PlayerSignManager managerCreate(){
         Config config;
-        ArrayList<PlayerSignInData> dataArrayList = new ArrayList<>();
+        Map<String, PlayerSignInData> dataMap = new HashMap<>();
         PlayerSignInData signInData;
         for(String name: Tool.getDefaultFiles("players")){
             config = new Config(SignInMainClass.MAIN_INSTANCE.getDataFolder()+"/players/"+name+".yml",Config.YAML);
@@ -35,22 +38,18 @@ public class PlayerSignManager {
             if(signInData.getSignMonth() != Tool.geMonth()){
                 signInData.reset();
             }
-            dataArrayList.add(signInData);
+            dataMap.put(name, signInData);
         }
-        return new PlayerSignManager(dataArrayList);
+        return new PlayerSignManager(dataMap);
 
     }
 
-    public ArrayList<PlayerSignInData> getPlayerSignInData() {
-        return playerSignInData;
+    public Collection<PlayerSignInData> getPlayerSignInData() {
+        return playerSignInData.values();
     }
 
     public PlayerSignInData getPlayerData(String playerName){
-        PlayerSignInData signInData = new PlayerSignInData(playerName);
-        if(!playerSignInData.contains(signInData)){
-            playerSignInData.add(signInData);
-        }
-        return playerSignInData.get(playerSignInData.indexOf(signInData));
+        return playerSignInData.computeIfAbsent(playerName, PlayerSignInData::new);
     }
 
 }

--- a/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
+++ b/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
@@ -6,7 +6,9 @@ import org.badfish.signin.utils.Tool;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author BadFish
@@ -14,6 +16,9 @@ import java.util.Map;
 public class PlayerSignManager {
 
     private Map<String, PlayerSignInData> playerSignInDataCache;
+
+    /** 标记从其他子服切换过来、数据尚未经过 DB 验证的玩家 */
+    private final Set<String> needsVerification = new HashSet<>();
 
     private PlayerSignManager(Map<String, PlayerSignInData> signInData){
         this.playerSignInDataCache = signInData;
@@ -46,8 +51,34 @@ public class PlayerSignManager {
         return data;
     }
 
+    /**
+     * 异步加载完成后写入缓存，并标记需要在首次写操作前验证
+     */
+    public void putPlayerData(String playerName, PlayerSignInData data) {
+        playerSignInDataCache.put(playerName, data);
+        needsVerification.add(playerName);
+    }
+
+    /**
+     * 验证完成后用 DB 最新数据刷新缓存，不重置验证标记
+     */
+    public void refreshCache(String playerName, PlayerSignInData data) {
+        playerSignInDataCache.put(playerName, data);
+    }
+
+    /** 判断该玩家是否需要在写操作前进行 DB 验证 */
+    public boolean needsVerification(String playerName) {
+        return needsVerification.contains(playerName);
+    }
+
+    /** 标记验证已完成 */
+    public void markVerified(String playerName) {
+        needsVerification.remove(playerName);
+    }
+
     public void removePlayerData(String playerName) {
         playerSignInDataCache.remove(playerName);
+        needsVerification.remove(playerName);
     }
 
     public boolean containsPlayer(String playerName) {

--- a/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
+++ b/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
@@ -13,33 +13,44 @@ import java.util.Map;
  */
 public class PlayerSignManager {
 
-    private Map<String, PlayerSignInData> playerSignInData;
+    private Map<String, PlayerSignInData> playerSignInDataCache;
 
     private PlayerSignManager(Map<String, PlayerSignInData> signInData){
-        this.playerSignInData = signInData;
+        this.playerSignInDataCache = signInData;
     }
 
     public static PlayerSignManager managerCreate(){
-        Map<String, PlayerSignInData> dataMap = new HashMap<>();
-        for (PlayerSignInData signInData : SignInMainClass.DATA_STORAGE.loadAll()) {
-            if (signInData.getSignMonth() == -1) {
-                signInData.setSignMonth(Tool.geMonth());
-            }
-            //如果是新的一个月那就重置累计进度
-            if (signInData.getSignMonth() != Tool.geMonth()) {
-                signInData.reset();
-            }
-            dataMap.put(signInData.getPlayerName(), signInData);
-        }
-        return new PlayerSignManager(dataMap);
+        return new PlayerSignManager(new HashMap<>());
     }
 
     public Collection<PlayerSignInData> getPlayerSignInData() {
-        return playerSignInData.values();
+        return playerSignInDataCache.values();
     }
 
-    public PlayerSignInData getPlayerData(String playerName){
-        return playerSignInData.computeIfAbsent(playerName, PlayerSignInData::new);
+    public PlayerSignInData getPlayerData(String playerName) {
+        PlayerSignInData data = playerSignInDataCache.get(playerName);
+        if (data == null) {
+            data = SignInMainClass.DATA_STORAGE.load(playerName);
+            if (data == null) {
+                data = new PlayerSignInData(playerName);
+            }
+            // 月份重置检查
+            if (data.getSignMonth() == -1) {
+                data.setSignMonth(Tool.geMonth());
+            }
+            if (data.getSignMonth() != Tool.geMonth()) {
+                data.reset();
+            }
+            playerSignInDataCache.put(playerName, data);
+        }
+        return data;
     }
 
+    public void removePlayerData(String playerName) {
+        playerSignInDataCache.remove(playerName);
+    }
+
+    public boolean containsPlayer(String playerName) {
+        return playerSignInDataCache.containsKey(playerName);
+    }
 }

--- a/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
+++ b/src/main/java/org/badfish/signin/manager/PlayerSignManager.java
@@ -1,11 +1,9 @@
 package org.badfish.signin.manager;
 
-import cn.nukkit.utils.Config;
 import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.data.PlayerSignInData;
 import org.badfish.signin.utils.Tool;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,26 +20,18 @@ public class PlayerSignManager {
     }
 
     public static PlayerSignManager managerCreate(){
-        Config config;
         Map<String, PlayerSignInData> dataMap = new HashMap<>();
-        PlayerSignInData signInData;
-        for(String name: Tool.getDefaultFiles("players")){
-            config = new Config(SignInMainClass.MAIN_INSTANCE.getDataFolder()+"/players/"+name+".yml",Config.YAML);
-            signInData = new PlayerSignInData(name, (ArrayList<String>) config.getStringList("signInDate"));
-            signInData.setCumulativeCount(config.getInt("cumulativeCount",0));
-            signInData.setRetroactiveCount(config.getInt("retroactiveCount",0));
-            signInData.setSignMonth(config.getInt("signMonth",-1));
-            if(signInData.getSignMonth() == -1){
+        for (PlayerSignInData signInData : SignInMainClass.DATA_STORAGE.loadAll()) {
+            if (signInData.getSignMonth() == -1) {
                 signInData.setSignMonth(Tool.geMonth());
             }
             //如果是新的一个月那就重置累计进度
-            if(signInData.getSignMonth() != Tool.geMonth()){
+            if (signInData.getSignMonth() != Tool.geMonth()) {
                 signInData.reset();
             }
-            dataMap.put(name, signInData);
+            dataMap.put(signInData.getPlayerName(), signInData);
         }
         return new PlayerSignManager(dataMap);
-
     }
 
     public Collection<PlayerSignInData> getPlayerSignInData() {

--- a/src/main/java/org/badfish/signin/panel/DisplayPanel.java
+++ b/src/main/java/org/badfish/signin/panel/DisplayPanel.java
@@ -11,7 +11,9 @@ import cn.nukkit.utils.TextFormat;
 import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.items.CumulativeItem;
 import org.badfish.signin.items.DateItem;
+import org.badfish.signin.panel.lib.AbstractFakeInventory;
 import org.badfish.signin.utils.Tool;
+import com.nukkitx.fakeinventories.inventory.DoubleChestFakeInventory;
 
 
 import java.util.Date;
@@ -27,8 +29,6 @@ public class DisplayPanel implements InventoryHolder {
     private static final int ITEM_INDEX = 36;
 
     private static final int LINE_SIZE = 9;
-
-
 
     /**
      * 画主页面
@@ -89,16 +89,18 @@ public class DisplayPanel implements InventoryHolder {
         displayPlayer(player,panel, TextFormat.colorize('&',"&b&l"+mon+"月签到"));
     }
 
-
-
-
-
-
     public void displayPlayer(Player player,Map<Integer, Item> itemMap,String name){
-        ChestInventoryPanel panel = new ChestInventoryPanel(this,name);
-        panel.setContents(itemMap);
-        panel.id = Entity.entityCount++;
-        player.addWindow(panel);
+        if (AbstractFakeInventory.USE_GAME_VERSION) {
+            DoubleChestFakeInventory panel = new DoubleChestFakeInventory(this);
+            panel.setName(name);
+            panel.setContents(itemMap);
+            player.addWindow(panel);
+        } else {
+            ChestInventoryPanel panel = new ChestInventoryPanel(this, name);
+            panel.setContents(itemMap);
+            panel.id = Entity.entityCount++;
+            player.addWindow(panel);
+        }
     }
 
 

--- a/src/main/java/org/badfish/signin/panel/DisplayPanel.java
+++ b/src/main/java/org/badfish/signin/panel/DisplayPanel.java
@@ -90,7 +90,7 @@ public class DisplayPanel implements InventoryHolder {
     }
 
     public void displayPlayer(Player player,Map<Integer, Item> itemMap,String name){
-        if (AbstractFakeInventory.USE_GAME_VERSION) {
+        if (AbstractFakeInventory.USE_GAME_VERSION) { // NKMOT使用内置的FakeInventory依赖
             DoubleChestFakeInventory panel = new DoubleChestFakeInventory(this);
             panel.setName(name);
             panel.setContents(itemMap);

--- a/src/main/java/org/badfish/signin/panel/lib/AbstractFakeInventory.java
+++ b/src/main/java/org/badfish/signin/panel/lib/AbstractFakeInventory.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 本类引用 SupermeMortal 的 FakeInventories 插件
@@ -26,16 +27,16 @@ public abstract class AbstractFakeInventory extends ContainerInventory {
     private static final BlockVector3 ZERO = new BlockVector3(0, 0, 0);
 
     private static final Map<Player, AbstractFakeInventory> OPEN = new ConcurrentHashMap<>();
+    private static final ExecutorService CLOSE_EXECUTOR = Executors.newSingleThreadExecutor();
 
     final Map<Player, List<BlockVector3>> blockPositions = new HashMap<>();
     private String title;
 
     static {
         try {
-            Class<?> c = Class.forName("cn.nukkit.GameVersion");
+            Class.forName("cn.nukkit.GameVersion");
             USE_GAME_VERSION = true;
         } catch (ClassNotFoundException ignored) {
-
         }
     }
 
@@ -78,22 +79,20 @@ public abstract class AbstractFakeInventory extends ContainerInventory {
      * @return 方块坐标*/
     protected abstract List<BlockVector3> onOpenBlock(Player who);
 
-    private ExecutorService service = Executors.newSingleThreadExecutor();
     @Override
     public void onClose(Player who) {
         super.onClose(who);
         OPEN.remove(who, this);
-        List<BlockVector3> blocks = blockPositions.get(who);
+        List<BlockVector3> blocks = blockPositions.remove(who);
+        if (blocks == null) return;
         for (int i = 0, size = blocks.size(); i < size; i++) {
             final int index = i;
-            service.execute(() -> {
+            CLOSE_EXECUTOR.execute(() -> {
                 Vector3 blockPosition = blocks.get(index).asVector3();
                 UpdateBlockPacket updateBlock = new UpdateBlockPacket();
-                if (USE_GAME_VERSION) {
-                    updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(who.getGameVersion(), who.getLevel().getBlock(blockPosition).getFullId());
-                } else if(IS_PM1E) {
+                if (IS_PM1E) {
                     updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(who.protocol, who.getLevel().getBlock(blockPosition).getFullId());
-                }else {
+                } else {
                     updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(who.getLevel().getBlock(blockPosition).getFullId());
                 }
                 updateBlock.flags = UpdateBlockPacket.FLAG_ALL_PRIORITY;
@@ -106,6 +105,21 @@ public abstract class AbstractFakeInventory extends ContainerInventory {
     }
 
 
+
+    /**
+     * 关闭线程池，插件卸载时调用
+     */
+    public static void shutdown() {
+        CLOSE_EXECUTOR.shutdown();
+        try {
+            if (!CLOSE_EXECUTOR.awaitTermination(3, TimeUnit.SECONDS)) {
+                CLOSE_EXECUTOR.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            CLOSE_EXECUTOR.shutdownNow();
+        }
+        OPEN.clear();
+    }
 
     @Override
     public String getTitle() {

--- a/src/main/java/org/badfish/signin/panel/lib/ChestFakeInventory.java
+++ b/src/main/java/org/badfish/signin/panel/lib/ChestFakeInventory.java
@@ -49,9 +49,7 @@ public class ChestFakeInventory extends AbstractFakeInventory{
 
     void placeChest(Player who, BlockVector3 pos) {
         UpdateBlockPacket updateBlock = new UpdateBlockPacket();
-        if (USE_GAME_VERSION) {
-            updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(who.getGameVersion(), BlockID.CHEST, 0);
-        } else if (IS_PM1E) {
+        if (IS_PM1E) {
             updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(who.protocol, BlockID.CHEST, 0);
         } else {
             updateBlock.blockRuntimeId = GlobalBlockPalette.getOrCreateRuntimeId(BlockID.CHEST, 0);

--- a/src/main/java/org/badfish/signin/storage/DataStorageFactory.java
+++ b/src/main/java/org/badfish/signin/storage/DataStorageFactory.java
@@ -1,0 +1,43 @@
+package org.badfish.signin.storage;
+
+import cn.nukkit.Server;
+import org.badfish.signin.SignInMainClass;
+import org.badfish.signin.storage.provider.DataStorageProvider;
+import org.badfish.signin.storage.provider.DatabaseDataStorageProvider;
+import org.badfish.signin.storage.provider.YamlDataStorageProvider;
+
+/**
+ * 数据存储工厂，根据配置创建对应的 DataStorage 实现
+ */
+public class DataStorageFactory {
+
+    public static DataStorageProvider create(String storageType) {
+        if ("database".equalsIgnoreCase(storageType)) {
+            if (Server.getInstance().getPluginManager().getPlugin("YRDatabase") == null) {
+                SignInMainClass.MAIN_INSTANCE.getLogger().warning(
+                        "配置了 database 存储但未安装 YRDatabase 插件，回退到 yaml 存储"
+                );
+                return createYaml();
+            }
+            try {
+                DataStorageProvider storage = new DatabaseDataStorageProvider();
+                storage.init();
+                SignInMainClass.MAIN_INSTANCE.getLogger().info("使用 YRDatabase 数据库存储");
+                return storage;
+            } catch (Exception e) {
+                SignInMainClass.MAIN_INSTANCE.getLogger().warning(
+                        "YRDatabase 初始化失败，回退到 yaml 存储: " + e.getMessage()
+                );
+                return createYaml();
+            }
+        }
+        return createYaml();
+    }
+
+    private static DataStorageProvider createYaml() {
+        DataStorageProvider storage = new YamlDataStorageProvider();
+        storage.init();
+        SignInMainClass.MAIN_INSTANCE.getLogger().info("使用 YAML 文件存储");
+        return storage;
+    }
+}

--- a/src/main/java/org/badfish/signin/storage/SignInEntity.java
+++ b/src/main/java/org/badfish/signin/storage/SignInEntity.java
@@ -1,0 +1,80 @@
+package org.badfish.signin.storage;
+
+import com.yirankuma.yrdatabase.api.annotation.Column;
+import com.yirankuma.yrdatabase.api.annotation.PrimaryKey;
+import com.yirankuma.yrdatabase.api.annotation.Table;
+
+/**
+ * 签到数据库实体
+ */
+@Table("signin_data")
+public class SignInEntity {
+
+    @PrimaryKey("player_name")
+    private String playerName;
+
+    /** 签到日期列表，逗号分隔的 yyyy-MM-dd 字符串 */
+    @Column(value = "sign_in_dates", type = "TEXT")
+    private String signInDates;
+
+    @Column("sign_month")
+    private int signMonth;
+
+    @Column("cumulative_count")
+    private int cumulativeCount;
+
+    @Column("retroactive_count")
+    private int retroactiveCount;
+
+    public SignInEntity() {
+    }
+
+    public SignInEntity(String playerName, String signInDates, int signMonth,
+                        int cumulativeCount, int retroactiveCount) {
+        this.playerName = playerName;
+        this.signInDates = signInDates;
+        this.signMonth = signMonth;
+        this.cumulativeCount = cumulativeCount;
+        this.retroactiveCount = retroactiveCount;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public String getSignInDates() {
+        return signInDates;
+    }
+
+    public void setSignInDates(String signInDates) {
+        this.signInDates = signInDates;
+    }
+
+    public int getSignMonth() {
+        return signMonth;
+    }
+
+    public void setSignMonth(int signMonth) {
+        this.signMonth = signMonth;
+    }
+
+    public int getCumulativeCount() {
+        return cumulativeCount;
+    }
+
+    public void setCumulativeCount(int cumulativeCount) {
+        this.cumulativeCount = cumulativeCount;
+    }
+
+    public int getRetroactiveCount() {
+        return retroactiveCount;
+    }
+
+    public void setRetroactiveCount(int retroactiveCount) {
+        this.retroactiveCount = retroactiveCount;
+    }
+}

--- a/src/main/java/org/badfish/signin/storage/provider/DataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/DataStorageProvider.java
@@ -1,0 +1,21 @@
+package org.badfish.signin.storage.provider;
+
+import org.badfish.signin.data.PlayerSignInData;
+
+import java.util.Collection;
+
+/**
+ * 玩家签到数据存储接口
+ */
+public interface DataStorageProvider {
+
+    void init();
+
+    Collection<PlayerSignInData> loadAll();
+
+    void save(PlayerSignInData data);
+
+    void saveAll(Collection<PlayerSignInData> dataCollection);
+
+    void close();
+}

--- a/src/main/java/org/badfish/signin/storage/provider/DataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/DataStorageProvider.java
@@ -1,6 +1,7 @@
 package org.badfish.signin.storage.provider;
 
 import org.badfish.signin.data.PlayerSignInData;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
@@ -11,9 +12,17 @@ public interface DataStorageProvider {
 
     void init();
 
+    /**
+     * 加载单个玩家数据，不存在返回 null
+     */
+    @Nullable
+    PlayerSignInData load(String playerName);
+
     Collection<PlayerSignInData> loadAll();
 
     void save(PlayerSignInData data);
+
+    void saveAsync(PlayerSignInData data);
 
     void saveAll(Collection<PlayerSignInData> dataCollection);
 

--- a/src/main/java/org/badfish/signin/storage/provider/DatabaseDataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/DatabaseDataStorageProvider.java
@@ -4,8 +4,8 @@ import com.yirankuma.yrdatabase.api.DatabaseManager;
 import com.yirankuma.yrdatabase.api.Repository;
 import com.yirankuma.yrdatabase.api.CacheStrategy;
 import com.yirankuma.yrdatabase.nukkit.YRDatabaseNukkit;
+import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.data.PlayerSignInData;
-import org.badfish.signin.storage.SignInEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +27,13 @@ public class DatabaseDataStorageProvider implements DataStorageProvider {
     }
 
     @Override
+    public PlayerSignInData load(String playerName) {
+        return repository.findById(playerName).join()
+                .map(this::toPlayerData)
+                .orElse(null);
+    }
+
+    @Override
     public Collection<PlayerSignInData> loadAll() {
         List<SignInEntity> entities = repository.findAll().join();
         Collection<PlayerSignInData> result = new ArrayList<>();
@@ -39,6 +46,15 @@ public class DatabaseDataStorageProvider implements DataStorageProvider {
     @Override
     public void save(PlayerSignInData data) {
         repository.save(toEntity(data), CacheStrategy.WRITE_THROUGH).join();
+    }
+
+    @Override
+    public void saveAsync(PlayerSignInData data) {
+        SignInEntity entity = toEntity(data.snapshot());
+        repository.save(entity, CacheStrategy.WRITE_THROUGH).exceptionally(e -> {
+            SignInMainClass.MAIN_INSTANCE.getLogger().error("异步保存玩家数据失败: " + data.getPlayerName(), e);
+            return null;
+        });
     }
 
     @Override

--- a/src/main/java/org/badfish/signin/storage/provider/DatabaseDataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/DatabaseDataStorageProvider.java
@@ -1,0 +1,79 @@
+package org.badfish.signin.storage.provider;
+
+import com.yirankuma.yrdatabase.api.DatabaseManager;
+import com.yirankuma.yrdatabase.api.Repository;
+import com.yirankuma.yrdatabase.api.CacheStrategy;
+import com.yirankuma.yrdatabase.nukkit.YRDatabaseNukkit;
+import org.badfish.signin.data.PlayerSignInData;
+import org.badfish.signin.storage.SignInEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * YRDatabase 数据库存储实现
+ */
+public class DatabaseDataStorageProvider implements DataStorageProvider {
+
+    private Repository<SignInEntity> repository;
+
+    @Override
+    public void init() {
+        DatabaseManager db = YRDatabaseNukkit.getDatabaseManager();
+        this.repository = db.getRepository(SignInEntity.class);
+    }
+
+    @Override
+    public Collection<PlayerSignInData> loadAll() {
+        List<SignInEntity> entities = repository.findAll().join();
+        Collection<PlayerSignInData> result = new ArrayList<>();
+        for (SignInEntity entity : entities) {
+            result.add(toPlayerData(entity));
+        }
+        return result;
+    }
+
+    @Override
+    public void save(PlayerSignInData data) {
+        repository.save(toEntity(data), CacheStrategy.WRITE_THROUGH).join();
+    }
+
+    @Override
+    public void saveAll(Collection<PlayerSignInData> dataCollection) {
+        List<SignInEntity> entities = dataCollection.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+        repository.saveAll(entities, CacheStrategy.WRITE_THROUGH).join();
+    }
+
+    @Override
+    public void close() {
+        // DatabaseManager 由 YRDatabase 插件管理生命周期，无需手动关闭
+    }
+
+    private SignInEntity toEntity(PlayerSignInData data) {
+        String dates = String.join(",", data.getSignIn());
+        return new SignInEntity(
+                data.getPlayerName(),
+                dates,
+                data.getSignMonth(),
+                data.getCumulativeCount(),
+                data.getRetroactiveCount()
+        );
+    }
+
+    private PlayerSignInData toPlayerData(SignInEntity entity) {
+        ArrayList<String> signIn = new ArrayList<>();
+        if (entity.getSignInDates() != null && !entity.getSignInDates().isEmpty()) {
+            signIn.addAll(Arrays.asList(entity.getSignInDates().split(",")));
+        }
+        PlayerSignInData data = new PlayerSignInData(entity.getPlayerName(), signIn);
+        data.setSignMonth(entity.getSignMonth());
+        data.setCumulativeCount(entity.getCumulativeCount());
+        data.setRetroactiveCount(entity.getRetroactiveCount());
+        return data;
+    }
+}

--- a/src/main/java/org/badfish/signin/storage/provider/SignInEntity.java
+++ b/src/main/java/org/badfish/signin/storage/provider/SignInEntity.java
@@ -1,4 +1,4 @@
-package org.badfish.signin.storage;
+package org.badfish.signin.storage.provider;
 
 import com.yirankuma.yrdatabase.api.annotation.Column;
 import com.yirankuma.yrdatabase.api.annotation.PrimaryKey;

--- a/src/main/java/org/badfish/signin/storage/provider/YamlDataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/YamlDataStorageProvider.java
@@ -1,0 +1,65 @@
+package org.badfish.signin.storage.provider;
+
+import cn.nukkit.utils.Config;
+import org.badfish.signin.SignInMainClass;
+import org.badfish.signin.data.PlayerSignInData;
+import org.badfish.signin.utils.Tool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * YAML 文件存储实现
+ */
+public class YamlDataStorageProvider implements DataStorageProvider {
+
+    @Override
+    public void init() {
+        // YAML 不需要额外初始化
+    }
+
+    @Override
+    public Collection<PlayerSignInData> loadAll() {
+        Collection<PlayerSignInData> result = new ArrayList<>();
+        for (String name : Tool.getDefaultFiles("players")) {
+            Config config = new Config(
+                    SignInMainClass.MAIN_INSTANCE.getDataFolder() + "/players/" + name + ".yml",
+                    Config.YAML
+            );
+            PlayerSignInData signInData = new PlayerSignInData(
+                    name,
+                    (ArrayList<String>) config.getStringList("signInDate")
+            );
+            signInData.setCumulativeCount(config.getInt("cumulativeCount", 0));
+            signInData.setRetroactiveCount(config.getInt("retroactiveCount", 0));
+            signInData.setSignMonth(config.getInt("signMonth", -1));
+            result.add(signInData);
+        }
+        return result;
+    }
+
+    @Override
+    public void save(PlayerSignInData data) {
+        Config config = new Config(
+                SignInMainClass.MAIN_INSTANCE.getDataFolder() + "/players/" + data.getPlayerName() + ".yml",
+                Config.YAML
+        );
+        config.set("signInDate", data.getSignIn());
+        config.set("signMonth", data.getSignMonth());
+        config.set("cumulativeCount", data.getCumulativeCount());
+        config.set("retroactiveCount", data.getRetroactiveCount());
+        config.save();
+    }
+
+    @Override
+    public void saveAll(Collection<PlayerSignInData> dataCollection) {
+        for (PlayerSignInData data : dataCollection) {
+            save(data);
+        }
+    }
+
+    @Override
+    public void close() {
+        // YAML 不需要关闭
+    }
+}

--- a/src/main/java/org/badfish/signin/storage/provider/YamlDataStorageProvider.java
+++ b/src/main/java/org/badfish/signin/storage/provider/YamlDataStorageProvider.java
@@ -1,10 +1,13 @@
 package org.badfish.signin.storage.provider;
 
+import cn.nukkit.Server;
+import cn.nukkit.scheduler.AsyncTask;
 import cn.nukkit.utils.Config;
 import org.badfish.signin.SignInMainClass;
 import org.badfish.signin.data.PlayerSignInData;
 import org.badfish.signin.utils.Tool;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -15,7 +18,27 @@ public class YamlDataStorageProvider implements DataStorageProvider {
 
     @Override
     public void init() {
-        // YAML 不需要额外初始化
+        File playersDir = new File(SignInMainClass.MAIN_INSTANCE.getDataFolder(), "players");
+        if (!playersDir.exists()) {
+            playersDir.mkdirs();
+        }
+    }
+
+    @Override
+    public PlayerSignInData load(String playerName) {
+        File file = new File(SignInMainClass.MAIN_INSTANCE.getDataFolder() + "/players/" + playerName + ".yml");
+        if (!file.exists()) {
+            return null;
+        }
+        Config config = new Config(file.getPath(), Config.YAML);
+        PlayerSignInData signInData = new PlayerSignInData(
+                playerName,
+                (ArrayList<String>) config.getStringList("signInDate")
+        );
+        signInData.setCumulativeCount(config.getInt("cumulativeCount", 0));
+        signInData.setRetroactiveCount(config.getInt("retroactiveCount", 0));
+        signInData.setSignMonth(config.getInt("signMonth", -1));
+        return signInData;
     }
 
     @Override
@@ -40,21 +63,39 @@ public class YamlDataStorageProvider implements DataStorageProvider {
 
     @Override
     public void save(PlayerSignInData data) {
-        Config config = new Config(
-                SignInMainClass.MAIN_INSTANCE.getDataFolder() + "/players/" + data.getPlayerName() + ".yml",
-                Config.YAML
-        );
-        config.set("signInDate", data.getSignIn());
-        config.set("signMonth", data.getSignMonth());
-        config.set("cumulativeCount", data.getCumulativeCount());
-        config.set("retroactiveCount", data.getRetroactiveCount());
-        config.save();
+        doSave(data);
+    }
+
+    @Override
+    public void saveAsync(PlayerSignInData data) {
+        PlayerSignInData snapshot = data.snapshot();
+        Server.getInstance().getScheduler().scheduleAsyncTask(SignInMainClass.MAIN_INSTANCE, new AsyncTask() {
+            @Override
+            public void onRun() {
+                doSave(snapshot);
+            }
+        });
     }
 
     @Override
     public void saveAll(Collection<PlayerSignInData> dataCollection) {
         for (PlayerSignInData data : dataCollection) {
             save(data);
+        }
+    }
+
+    private void doSave(PlayerSignInData data) {
+        // 对同一玩家文件加锁，防止并发写入导致数据覆盖
+        synchronized (data.getPlayerName().intern()) {
+            Config config = new Config(
+                    SignInMainClass.MAIN_INSTANCE.getDataFolder() + "/players/" + data.getPlayerName() + ".yml",
+                    Config.YAML
+            );
+            config.set("signInDate", data.getSignIn());
+            config.set("signMonth", data.getSignMonth());
+            config.set("cumulativeCount", data.getCumulativeCount());
+            config.set("retroactiveCount", data.getRetroactiveCount());
+            config.save();
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
+# 存储类型: yaml / database (database 需要安装 YRDatabase 插件)
+storage-type: yaml
+
 join-display: true
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 # 存储类型: yaml / database (database 需要安装 YRDatabase 插件)
 storage-type: yaml
 
+# 加入时是否自动弹出签到面板
 join-display: true
 
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SignIn
 main: org.badfish.signin.SignInMainClass
-version: 1.2.0
+version: "${version}"
 api: 1.0.11
 author: 某吃瓜咸鱼
 commands:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,8 @@ main: org.badfish.signin.SignInMainClass
 version: "${version}"
 api: 1.0.11
 author: 某吃瓜咸鱼
+softdepend:
+  - YRDatabase
 commands:
   qd:
     description: "签到插件"


### PR DESCRIPTION
## Summary

本次更新为 SignIn 插件引入数据库存储方案，并对数据管理层和 GUI 系统进行了全面的性能优化与内存泄漏修复。版本从 1.2.1 升级至 1.3.0-SNAPSHOT。

## 主要变更

### 新增：数据库存储支持
- 新增 `DataStorageProvider` 存储接口，抽象数据持久化层
- 新增 `YamlDataStorageProvider`（YAML 文件存储，原有逻辑迁移）
- 新增 `DatabaseDataStorageProvider`（YRDatabase 数据库存储）
- 新增 `DataStorageFactory` 工厂类，根据 `config.yml` 中 `storage-type` 配置自动选择存储方式
- 新增 `SignInEntity` 数据库实体映射类
- 数据库不可用时自动回退到 YAML 存储

### 性能优化
- `PlayerSignManager` 内部数据结构从 `ArrayList` 改为 `HashMap`，玩家数据查找从 O(n) 优化为 O(1)
- 玩家数据改为按需加载（登录时加载），不再启动时全量加载所有玩家文件
- 数据保存改为异步执行（`saveAsync`），避免阻塞主线程
- `PlayerSignInData` 新增 `snapshot()` 方法，异步保存时使用数据快照防止并发问题
- YAML 存储对同一玩家文件加锁（`synchronized`），防止并发写入数据覆盖
- `RoundItem` 概率计算从自实现的小数位算法改为 `ThreadLocalRandom`，修复概率计算偏差

### 内存泄漏修复
- 玩家退出时从内存缓存中移除数据（`removePlayerData`），防止内存持续增长
- 玩家退出时同步清理 `isLogin` 列表
- `AbstractFakeInventory` 的 `ExecutorService` 从每个实例独立创建改为全局共享静态线程池，避免线程泄漏
- 关闭面板时正确清理 `blockPositions`（使用 `remove` 替代 `get`）
- 插件卸载时正确关闭线程池和清理资源（`shutdown()` 方法）

### GUI 兼容性改进
- Nukkit-MOT 核心使用 FakeInventories 依赖
- PM1E 核心保留原有 `ChestInventoryPanel` 方式
- 内嵌 FakeInventories 库并通过 maven-shade-plugin 重定位包路径，避免与其他插件冲突

### 其他改进
- `plugin.yml` 版本号改为从 `pom.xml` 自动读取（`${version}`）
- 新增 `YRDatabase` 为 softdepend
- 插件生命周期完善：`onLoad` 初始化实例，`onDisable` 保存数据并关闭资源
- `/qd reset` 命令支持异步重置离线玩家数据
- `/qd give` 命令支持离线玩家补签卡发放
- 签到和领取累计奖励后立即触发异步保存